### PR TITLE
Use configuration of current store instead of default store

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -1,6 +1,8 @@
 <?php
 namespace Paymentwall\Paymentwall\Helper;
 
+use Magento\Store\Model\ScopeInterface;
+
 class Config extends \Magento\Framework\App\Helper\AbstractHelper
 {
     private $config;
@@ -15,24 +17,24 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     {
         \Paymentwall_Config::getInstance()->set([
             'api_type' => \Paymentwall_Config::API_GOODS,
-            'public_key' => $this->config->getValue('payment/paymentwall/api_key'),
-            'private_key' => $this->config->getValue('payment/paymentwall/secret_key')
+            'public_key' => $this->config->getValue('payment/paymentwall/api_key', ScopeInterface::SCOPE_STORE),
+            'private_key' => $this->config->getValue('payment/paymentwall/secret_key', ScopeInterface::SCOPE_STORE)
         ]);
     }
 
     public function getInitBrickConfig($isPingback = false)
     {
-        $testMode = $this->config->getValue('payment/brick/test_mode');
-        $privateTestKey = $this->config->getValue('payment/brick/private_test_key');
-        $secretKey = $this->config->getValue('payment/brick/secret_key');
+        $testMode = $this->config->getValue('payment/brick/test_mode', ScopeInterface::SCOPE_STORE);
+        $privateTestKey = $this->config->getValue('payment/brick/private_test_key', ScopeInterface::SCOPE_STORE);
+        $secretKey = $this->config->getValue('payment/brick/secret_key', ScopeInterface::SCOPE_STORE);
         if ($isPingback) {
             \Paymentwall_Config::getInstance()->set([
                 'private_key' => $testMode ? $privateTestKey : $secretKey
             ]);
         } else {
-            $publicTestKey = $this->config->getValue('payment/brick/public_test_key');
-            $publicKey = $this->config->getValue('payment/brick/public_key');
-            $privateKey = $this->config->getValue('payment/brick/private_key');
+            $publicTestKey = $this->config->getValue('payment/brick/public_test_key', ScopeInterface::SCOPE_STORE);
+            $publicKey = $this->config->getValue('payment/brick/public_key', ScopeInterface::SCOPE_STORE);
+            $privateKey = $this->config->getValue('payment/brick/private_key', ScopeInterface::SCOPE_STORE);
             \Paymentwall_Config::getInstance()->set([
                 'api_type' => \Paymentwall_Config::API_GOODS,
                 'public_key' => $testMode ? $publicTestKey : $publicKey,
@@ -43,6 +45,6 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function getConfig($name, $type = 'paymentwall')
     {
-        return $this->config->getValue("payment/{$type}/{$name}");
+        return $this->config->getValue("payment/{$type}/{$name}", ScopeInterface::SCOPE_STORE);
     }
 }


### PR DESCRIPTION
Currently only default config is used for config. So it is not possible, to set some Websites in Test mode or add different api-keys per Website.
This PR use the config of current scope